### PR TITLE
Feature/user/order-product: 주문조회 날짜 데이터 NPE 오류 수정

### DIFF
--- a/src/main/java/com/farmer/backend/api/controller/orderproduct/OrderProductController.java
+++ b/src/main/java/com/farmer/backend/api/controller/orderproduct/OrderProductController.java
@@ -51,9 +51,9 @@ public class OrderProductController {
     @ApiDocumentResponse
     @Operation(summary = "주문내역 전체 조회", description = "현재 로그인 한 사용자의 전체 주문내역을 조회합니다.")
     @GetMapping("/order-list")
-    public List<ResponseOrderProductDetailDto> orderList(RequestOrderProductStatusSearchDto statusSearchDto,
-                                                         @AuthenticationPrincipal MemberAdapter member) {
-
+    public List<ResponseOrderProductDetailDto> orderList(@AuthenticationPrincipal MemberAdapter member,
+                                                         RequestOrderProductStatusSearchDto statusSearchDto) {
+        log.info("member={}", member.getMember().getEmail());
         return orderProductService.orderList(statusSearchDto, member.getUsername());
     }
 }

--- a/src/main/java/com/farmer/backend/api/service/orderproduct/OrderProductService.java
+++ b/src/main/java/com/farmer/backend/api/service/orderproduct/OrderProductService.java
@@ -14,6 +14,7 @@ import com.farmer.backend.domain.orders.Orders;
 import com.farmer.backend.exception.CustomException;
 import com.farmer.backend.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class OrderProductService {
 
@@ -63,6 +65,7 @@ public class OrderProductService {
         Member findMember = memberRepository.findByEmail(userId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         List<Orders> orderList = orderRepository.findByMemberId(findMember.getId());
         List<ResponseOrderProductDetailDto> orderProductList = new ArrayList<>();
+        log.info("userId={}", userId);
         for (Orders orders : orderList) {
             orderProductList = orderProductQueryRepositoryImpl.findUserOrderProductDetail(statusSearchDto, orders.getId());
         }

--- a/src/main/java/com/farmer/backend/domain/orderproduct/OrderProductQueryRepositoryImpl.java
+++ b/src/main/java/com/farmer/backend/domain/orderproduct/OrderProductQueryRepositoryImpl.java
@@ -9,10 +9,14 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -23,6 +27,7 @@ import static com.farmer.backend.domain.orders.QOrders.orders;
 
 
 @Repository
+@Slf4j
 public class OrderProductQueryRepositoryImpl implements OrderProductQueryRepository {
 
     private final JPAQueryFactory query;
@@ -74,17 +79,17 @@ public class OrderProductQueryRepositoryImpl implements OrderProductQueryReposit
                 .where(
                         orderProduct.orders.id.eq(orderId),
                         eqOrderStatus(statusSearchDto.getOrderStatus()),
-                        betweenDatetime(statusSearchDto.getStartDate().atStartOfDay(), statusSearchDto.getEndDate().atStartOfDay())
+                        betweenDatetime(statusSearchDto.getStartDate(), statusSearchDto.getEndDate())
                 )
                 .fetch();
         return productOrderList;
     }
 
-    private BooleanExpression betweenDatetime(LocalDateTime startDate, LocalDateTime endDate) {
+    private BooleanExpression betweenDatetime(LocalDate startDate, LocalDate endDate) {
         if (Objects.isNull(startDate) || Objects.isNull(endDate)) {
             return null;
         }
-        return orders.createdDate.between(startDate, endDate);
+        return orders.createdDate.between(startDate.atStartOfDay(), endDate.atStartOfDay());
     }
 
     private BooleanExpression eqOrderStatus(OrderStatus orderStatus) {

--- a/src/test/java/com/farmer/backend/api/controller/orderproduct/OrderProductControllerTest.java
+++ b/src/test/java/com/farmer/backend/api/controller/orderproduct/OrderProductControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collection;
 import java.util.List;
 
 
@@ -67,12 +69,12 @@ class OrderProductControllerTest {
 
         RequestOrderProductStatusSearchDto statusSearchDto = new RequestOrderProductStatusSearchDto();
 
-        LocalDate st = LocalDate.of(2022, 03, 05);
-        LocalDate ed = LocalDate.of(2023, 07, 11);
-        statusSearchDto.setStartDate(st);
-        statusSearchDto.setEndDate(ed);
+//        LocalDate st = LocalDate.of(2022, 03, 05);
+//        LocalDate ed = LocalDate.of(2023, 07, 11);
+//        statusSearchDto.setStartDate(st);
+//        statusSearchDto.setEndDate(ed);
 
-        List<ResponseOrderProductDetailDto> responseOrderProductDetailDtos = orderProductController.orderList(statusSearchDto, memberAdapter);
+        List<ResponseOrderProductDetailDto> responseOrderProductDetailDtos = orderProductController.orderList(memberAdapter, statusSearchDto);
         for (ResponseOrderProductDetailDto responseOrderProductDetailDto : responseOrderProductDetailDtos) {
             log.info("responseOrderProductDetailDto={}", responseOrderProductDetailDto.getProductName());
         }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- [x] 기존의 주문조회 기능에 날짜 정보가 없다면 NULL이 Querydsl 진입함
- [x] LocalDateTime의 함수를 삭제하고 betweenDatetime 메서드 안에서 해당 함수를 리턴

Closes #{84}
