### PR TITLE
Feature/member/orders: 장바구니 삭제 로직 변경

### DIFF
--- a/src/main/java/com/farmer/backend/api/controller/cart/CartController.java
+++ b/src/main/java/com/farmer/backend/api/controller/cart/CartController.java
@@ -7,7 +7,6 @@ import com.farmer.backend.api.controller.cart.response.ResponseCartProductQuanti
 import com.farmer.backend.api.controller.cart.response.ResponseTotalPriceAndCountDto;
 import com.farmer.backend.api.service.cart.CartService;
 import com.farmer.backend.config.ApiDocumentResponse;
-import com.farmer.backend.domain.orderproduct.OrderProductRepository;
 import com.farmer.backend.exception.CustomException;
 import com.farmer.backend.exception.ErrorCode;
 import com.farmer.backend.login.general.MemberAdapter;
@@ -20,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -72,10 +70,13 @@ public class CartController {
      */
     @ApiDocumentResponse
     @Operation(summary = "장바구니 상품 삭제", description = "장바구니의 상품을 삭제합니다.")
-    @PostMapping("/remove-product/{cartId}")
-    public ResponseEntity removeToCartProduct(@PathVariable Long[] cartId, @AuthenticationPrincipal MemberAdapter member) {
-        cartService.removeToCartProduct(cartId);
-        return new ResponseEntity(HttpStatus.OK);
+    @PostMapping("/remove-product")
+    public ResponseEntity removeToCartProduct(@RequestBody List<Long> cartId, @AuthenticationPrincipal MemberAdapter member) {
+        int resultSize = cartService.removeToCartProduct(cartId, member.getMember());
+        if (resultSize == 0) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+        return ResponseEntity.ok(resultSize);
     }
 
     /**

--- a/src/main/java/com/farmer/backend/api/service/cart/CartService.java
+++ b/src/main/java/com/farmer/backend/api/service/cart/CartService.java
@@ -16,12 +16,9 @@ import com.farmer.backend.exception.ErrorCode;
 import com.farmer.backend.login.general.MemberAdapter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -79,14 +76,23 @@ public class CartService {
 
     /**
      * 장바구니 상품 삭제
+     *
      * @param cartId 장바구니 일련번호
+     * @param member
+     * @return
      */
     @Transactional
-    public void removeToCartProduct(Long[] cartId) {
-        for (Long id : cartId) {
-            Cart findCartProduct = cartRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUNT));
-            cartRepository.delete(findCartProduct);
+    public int removeToCartProduct(List<Long> cartId, Member member) {
+        List<Cart> cartList = cartId.stream()
+                .map(cart -> cartRepository.findById(cart).orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUNT)))
+                .collect(Collectors.toList());
+
+        int deleteSize = cartList.stream().filter(cart -> cart.getMember().getId() == member.getId()).collect(Collectors.toList()).size();
+        if (deleteSize != cartId.size()) {
+            return 0;
         }
+        cartList.forEach(cart -> cartRepository.delete(cart));
+        return deleteSize;
     }
 
     /**

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -2,7 +2,7 @@ jwt:
   secretKey: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
 
   access:
-    expiration: 60000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
+    expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
     header: Authorization
 
   refresh:

--- a/src/test/java/com/farmer/backend/api/service/cart/CartServiceTest.java
+++ b/src/test/java/com/farmer/backend/api/service/cart/CartServiceTest.java
@@ -69,7 +69,7 @@ class CartServiceTest {
     @Test
     @DisplayName("장바구니 상품 수량 변경")
     void changeQuantityAction() {
-        RequestCartProductQuantityDto requestCartProductQuantityDto = new RequestCartProductQuantityDto(1922L, "plus");
+        RequestCartProductQuantityDto requestCartProductQuantityDto = new RequestCartProductQuantityDto(2429L, "plus");
         Member member = memberRepository.findByEmail("codms7020@naver.com").orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         Cart findCartProduct = cartRepository.findById(requestCartProductQuantityDto.getCartId()).orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUNT));
         Integer originCount = findCartProduct.getCount();


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- [x] POST 전송 방식으로 PathVariable로 파라미터에 장바구니 일련번호를 요청 받아 온 기존 로직에서, Body에 JSON 형태로 요청 받을 수 있도록 변경
- [x] 삭제 할 해당 회원이 가지고 있는 장바구니 데이터가 아닌 다른 데이터를 삭제 하려고 시도 할때 예외 처리 구문을 추가함.
- [x] 삭제 할 데이터의 갯수와, 실제로 삭제되는 데이터의 갯수를 비교해서 동일하지 않다면 잘못 된 접근이므로 예외처리를 구성함.
- [x] 상태값만 응답 했던 기존 로직에서, 삭제 할 장바구니 데이터의 갯수를 같이 응답해서 프론트에서 더 효율적인 인터페이스 처리를 할 수 있게끔 변경

Closes #278 
