### PR TITLE
Feature/member/orders: 장바구니 상품 추가 로직 변경

### DIFF
--- a/src/main/java/com/farmer/backend/api/service/cart/CartService.java
+++ b/src/main/java/com/farmer/backend/api/service/cart/CartService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,7 +41,14 @@ public class CartService {
     @Transactional
     public void addToCart(RequestProductCartDto productCartDto, String memberEmail) {
         Member findMember = memberRepository.findByEmail(memberEmail).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        cartRepository.save(productCartDto.toEntity(findMember));
+        Optional<Cart> findCart = cartRepository.findByProductAndMember(productCartDto.getProduct(), findMember);
+        if (!findCart.isEmpty()) {
+            Integer productCount = findCart.get().getCount();
+            productCount++;
+            findCart.get().cartProductQuantityUpdate(productCount);
+        } else {
+            cartRepository.save(productCartDto.toEntity(findMember));
+        }
     }
 
     /**

--- a/src/main/java/com/farmer/backend/domain/cart/CartQueryRepositoryImpl.java
+++ b/src/main/java/com/farmer/backend/domain/cart/CartQueryRepositoryImpl.java
@@ -38,6 +38,7 @@ public class CartQueryRepositoryImpl implements CartQueryRepository{
                         cart.product.price.multiply(cart.count)
                 ))
                 .from(cart)
+                .where(cart.member.eq(findMember))
                 .fetch();
 
     }

--- a/src/main/java/com/farmer/backend/domain/cart/CartRepository.java
+++ b/src/main/java/com/farmer/backend/domain/cart/CartRepository.java
@@ -1,10 +1,13 @@
 package com.farmer.backend.domain.cart;
 
 import com.farmer.backend.domain.member.Member;
+import com.farmer.backend.domain.product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long>, CartQueryRepository {
 
+    Optional<Cart> findByProductAndMember(Product product, Member findMember);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- [x] 상품을 장바구니에 추가할 때, 기존에 장바구니에 담겨있던 상품과 동일한 상품이면, 장바구니 데이터를 새로 생성하지 않고 기존에 있는 상품의 수량을 추가해준다.
- [x] 기존 장바구니에 상품이 존재하지 않다면, 그때 장바구니에 데이터를 추가해준다.

Closes #281 
