### PR TITLE
Feature/member/orders: 장바구니 합계금액에 옵션 금액을 합산하여 조회

### DIFF
--- a/src/main/java/com/farmer/backend/api/controller/cart/response/ResponseCartProductListDto.java
+++ b/src/main/java/com/farmer/backend/api/controller/cart/response/ResponseCartProductListDto.java
@@ -3,8 +3,10 @@ package com.farmer.backend.api.controller.cart.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @Builder
 public class ResponseCartProductListDto {
@@ -15,6 +17,7 @@ public class ResponseCartProductListDto {
     private String productName;
     private Long optionId;
     private String optionName;
+    private Integer optionPrice;
     private Integer count;
     private Integer productPrice;
     private Integer totalPrice;

--- a/src/main/java/com/farmer/backend/api/controller/orderproduct/response/ResponseOrderProductDetailDto.java
+++ b/src/main/java/com/farmer/backend/api/controller/orderproduct/response/ResponseOrderProductDetailDto.java
@@ -1,6 +1,7 @@
 package com.farmer.backend.api.controller.orderproduct.response;
 
 import com.farmer.backend.domain.orders.OrderStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ public class ResponseOrderProductDetailDto {
 
     private String serialNumber;
     private String imgUrl;
+    private Long orderProductId;
     private Long productId;
     private String productName;
     private Integer count;
@@ -21,9 +23,10 @@ public class ResponseOrderProductDetailDto {
     private Long orderPrice;
     private OrderStatus orderStatus;
 
-    public ResponseOrderProductDetailDto(String serialNumber, String imgUrl, Long productId, String productName, Integer count, String optionName, Integer optionPrice, Long price, Long orderPrice, OrderStatus orderStatus) {
+    public ResponseOrderProductDetailDto(String serialNumber, String imgUrl, Long orderProductId, Long productId, String productName, Integer count, String optionName, Integer optionPrice, Long price, Long orderPrice, OrderStatus orderStatus) {
         this.serialNumber = serialNumber;
         this.imgUrl = imgUrl;
+        this.orderProductId = orderProductId;
         this.productId = productId;
         this.productName = productName;
         this.count = count;

--- a/src/main/java/com/farmer/backend/domain/cart/CartQueryRepositoryImpl.java
+++ b/src/main/java/com/farmer/backend/domain/cart/CartQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.farmer.backend.domain.cart;
 import com.farmer.backend.api.controller.cart.response.ResponseCartProductListDto;
 import com.farmer.backend.api.controller.cart.response.ResponseCartProductQuantityDto;
 import com.farmer.backend.domain.member.Member;
+import com.farmer.backend.domain.options.QOptions;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,7 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static com.farmer.backend.domain.cart.QCart.cart;
+import static com.farmer.backend.domain.options.QOptions.options;
 
 @Repository
 public class CartQueryRepositoryImpl implements CartQueryRepository{
@@ -31,13 +33,14 @@ public class CartQueryRepositoryImpl implements CartQueryRepository{
                         cart.product.id,
                         cart.product.thumbnailImg,
                         cart.product.name,
-                        cart.options.id,
-                        cart.options.optionName,
+                        options.id,
+                        options.optionName,
                         cart.count,
                         cart.product.price,
                         cart.product.price.multiply(cart.count)
                 ))
                 .from(cart)
+                .leftJoin(options).on(options.eq(cart.options))
                 .where(cart.member.eq(findMember))
                 .fetch();
 

--- a/src/main/java/com/farmer/backend/domain/orderproduct/OrderProductQueryRepositoryImpl.java
+++ b/src/main/java/com/farmer/backend/domain/orderproduct/OrderProductQueryRepositoryImpl.java
@@ -64,6 +64,7 @@ public class OrderProductQueryRepositoryImpl implements OrderProductQueryReposit
                                 ResponseOrderProductDetailDto.class,
                                 orders.orderNumber,
                                 orderProduct.product.thumbnailImg,
+                                orderProduct.id,
                                 orderProduct.product.id,
                                 orderProduct.product.name,
                                 orderProduct.count,

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -2,7 +2,7 @@ jwt:
   secretKey: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
 
   access:
-    expiration: 60000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
+    expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
     header: Authorization
 
   refresh:

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -2,7 +2,7 @@ jwt:
   secretKey: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
 
   access:
-    expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
+    expiration: 60000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
     header: Authorization
 
   refresh:

--- a/src/test/java/com/farmer/backend/api/service/cart/CartServiceTest.java
+++ b/src/test/java/com/farmer/backend/api/service/cart/CartServiceTest.java
@@ -69,8 +69,7 @@ class CartServiceTest {
     @Test
     @DisplayName("장바구니 상품 수량 변경")
     void changeQuantityAction() {
-        RequestCartProductQuantityDto requestCartProductQuantityDto = new RequestCartProductQuantityDto(2429L, "plus");
-        Member member = memberRepository.findByEmail("codms7020@naver.com").orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        RequestCartProductQuantityDto requestCartProductQuantityDto = new RequestCartProductQuantityDto(3090L, "plus");
         Cart findCartProduct = cartRepository.findById(requestCartProductQuantityDto.getCartId()).orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUNT));
         Integer originCount = findCartProduct.getCount();
         Integer beforeCount = findCartProduct.getCount();


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- [x] 기존 장바구니 합계금액은 상품 수량 x 상품 금액에만 적용 되어있음을 확인 후 옵션 금액도 합산할 수 있도록 쿼리 개선

Closes #294 
