### PR TITLE
fix: 상품의 옵션이 존재하지 않을때에도 장바구니에 데이터 추가

### DIFF
--- a/src/main/java/com/farmer/backend/api/service/cart/CartService.java
+++ b/src/main/java/com/farmer/backend/api/service/cart/CartService.java
@@ -47,7 +47,15 @@ public class CartService {
             productCount++;
             findCart.get().cartProductQuantityUpdate(productCount);
         } else {
-            cartRepository.save(productCartDto.toEntity(findMember));
+            if (productCartDto.getOption() == null) {
+                cartRepository.save(Cart.builder()
+                                .product(productCartDto.getProduct())
+                                .member(findMember)
+                                .count(productCartDto.getCount())
+                                .build());
+            } else {
+                cartRepository.save(productCartDto.toEntity(findMember));
+            }
         }
     }
 


### PR DESCRIPTION
### ✅ 작업한 내용
- [x] 상품 장바구니 등록시 옵션이 없을때에도 추가되도록 코드 수정

- Resolved: #이슈번호
