### PR TITLE
Feature/admin/orders: 어드민 주문관리 페이지 주문상세정보 API 개발

### DIFF
--- a/src/main/java/com/farmer/backend/api/controller/AdminApiController.java
+++ b/src/main/java/com/farmer/backend/api/controller/AdminApiController.java
@@ -278,16 +278,6 @@ public class AdminApiController {
         return productService.searchActionProductList(pageRequest.of(), productName);
     }
 
-    /**
-     * 주문 관리 페이지(주문 단건 조회)
-     */
-    @ApiDocumentResponse
-    @Operation(summary = "주문 단건 조회", description = "주문 한건을 조회합니다")
-    @GetMapping("/order/{orderId}")
-    public List<Object> orderInfo(@PathVariable Long orderId) {
-        return orderService.orderInfo(orderId);
-    }
-
     @ApiDocumentResponse
     @Operation(summary = "주문 상태 변경", description = "주문 한 건 상태를 변경합니다.")
     @PostMapping("/order-update/{orderId}")

--- a/src/main/java/com/farmer/backend/api/controller/admin/order/OrderController.java
+++ b/src/main/java/com/farmer/backend/api/controller/admin/order/OrderController.java
@@ -1,14 +1,19 @@
 package com.farmer.backend.api.controller.admin.order;
 
+import com.farmer.backend.api.controller.admin.order.response.ResponseOrderDetailDto;
 import com.farmer.backend.api.controller.admin.order.response.ResponseOrderListDto;
 import com.farmer.backend.api.controller.user.order.request.SearchOrdersCondition;
+import com.farmer.backend.api.controller.user.order.response.ResponseOrderInfoDto;
+import com.farmer.backend.api.controller.user.order.response.ResponseOrdersDto;
 import com.farmer.backend.api.service.order.OrderService;
 import com.farmer.backend.config.ApiDocumentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +22,7 @@ import java.util.List;
 @RestController(value = "admin.Controller")
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/api/admin")
+@RequestMapping("/api/admin/orders")
 @Tag(name = "OrderAdminController", description = "백오피스 주문 API")
 public class OrderController {
 
@@ -25,9 +30,17 @@ public class OrderController {
 
     @ApiDocumentResponse
     @Operation(summary = "주문 전체조회", description = "관리자 페이지에서 주문 정보를 전체 조회합니다.")
-    @GetMapping("/order-list")
+    @GetMapping
     public List<ResponseOrderListDto> orderList(SearchOrdersCondition searchOrdersCondition) {
         return orderService.orderList(searchOrdersCondition);
+    }
+
+    @ApiDocumentResponse
+    @Operation(summary = "주문상세 정보조회", description = "관리자 페이지에서 주문 상세정보를 조회합니다.")
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ResponseOrderDetailDto> orderDetail(@PathVariable Long orderId) {
+        ResponseOrderDetailDto orderDetail = orderService.orderDetail(orderId);
+        return ResponseEntity.ok(orderDetail);
     }
 
 }

--- a/src/main/java/com/farmer/backend/api/controller/admin/order/response/ResponseOrderDetailDto.java
+++ b/src/main/java/com/farmer/backend/api/controller/admin/order/response/ResponseOrderDetailDto.java
@@ -1,0 +1,19 @@
+package com.farmer.backend.api.controller.admin.order.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ResponseOrderDetailDto {
+
+    private String orderNumber;
+    private LocalDateTime createdDate;
+    private String nickname;
+    private String phoneNumber;
+    private String address;
+    private String email;
+
+}

--- a/src/main/java/com/farmer/backend/api/service/cart/CartService.java
+++ b/src/main/java/com/farmer/backend/api/service/cart/CartService.java
@@ -47,7 +47,15 @@ public class CartService {
             productCount++;
             findCart.get().cartProductQuantityUpdate(productCount);
         } else {
-            cartRepository.save(productCartDto.toEntity(findMember));
+            if (productCartDto.getOption() == null) {
+                cartRepository.save(Cart.builder()
+                                .product(productCartDto.getProduct())
+                                .member(findMember)
+                                .count(productCartDto.getCount())
+                                .build());
+            } else {
+                cartRepository.save(productCartDto.toEntity(findMember));
+            }
         }
     }
 

--- a/src/main/java/com/farmer/backend/api/service/cart/CartService.java
+++ b/src/main/java/com/farmer/backend/api/service/cart/CartService.java
@@ -44,8 +44,7 @@ public class CartService {
         Optional<Cart> findCart = cartRepository.findByProductAndMember(productCartDto.getProduct(), findMember);
         if (!findCart.isEmpty()) {
             Integer productCount = findCart.get().getCount();
-            productCount++;
-            findCart.get().cartProductQuantityUpdate(productCount);
+            findCart.get().cartProductQuantityUpdate(productCount + productCartDto.getCount());
         } else {
             if (productCartDto.getOption() == null) {
                 cartRepository.save(Cart.builder()

--- a/src/main/java/com/farmer/backend/api/service/order/OrderService.java
+++ b/src/main/java/com/farmer/backend/api/service/order/OrderService.java
@@ -1,5 +1,6 @@
 package com.farmer.backend.api.service.order;
 
+import com.farmer.backend.api.controller.admin.order.response.ResponseOrderDetailDto;
 import com.farmer.backend.api.controller.admin.order.response.ResponseOrderListDto;
 import com.farmer.backend.api.controller.user.order.request.RequestOrderInfoDto;
 import com.farmer.backend.api.controller.user.order.request.RequestOrderProductDto;
@@ -56,19 +57,8 @@ public class OrderService {
      * @return
      */
     @Transactional(readOnly = true)
-    public List<Object> orderInfo(Long orderId) {
-        List<Object> orderDetailContent = new ArrayList<>();
-        Map<String, List<ResponseOrdersAndPaymentDto>> ordersAndPaymentMap = new HashMap<>();
-        Map<String, List<ResponseOrderDetailDto>> orderDetailMap = new HashMap<>();
-        List<ResponseOrdersAndPaymentDto> ordersAndPayment = orderQueryRepositoryImpl.findOrdersAndPayment(orderId);
-        List<ResponseOrderDetailDto> orderDetail = orderProductQueryRepositoryImpl.findOrderDetail(orderId);
-
-        ordersAndPaymentMap.put("주문 결제정보", ordersAndPayment);
-        orderDetailMap.put("주문상품 상세정보", orderDetail);
-        orderDetailContent.add(ordersAndPaymentMap);
-        orderDetailContent.add(orderDetailMap);
-
-        return orderDetailContent;
+    public ResponseOrderDetailDto orderDetail(Long orderId) {
+        return orderQueryRepositoryImpl.findByOrderDetail(orderId);
     }
     @Transactional
     public void orderStatusUpdate(Long orderId, String orderStatus) {

--- a/src/main/java/com/farmer/backend/domain/orders/OrderQueryRepository.java
+++ b/src/main/java/com/farmer/backend/domain/orders/OrderQueryRepository.java
@@ -1,5 +1,6 @@
 package com.farmer.backend.domain.orders;
 
+import com.farmer.backend.api.controller.admin.order.response.ResponseOrderDetailDto;
 import com.farmer.backend.api.controller.admin.order.response.ResponseOrderListDto;
 import com.farmer.backend.api.controller.user.order.response.ResponseOrdersAndPaymentDto;
 import com.farmer.backend.api.controller.user.order.response.ResponseOrdersDto;
@@ -15,4 +16,5 @@ public interface OrderQueryRepository {
     List<ResponseOrdersAndPaymentDto> findOrdersAndPayment(Long orderId);
 
 
+    ResponseOrderDetailDto findByOrderDetail(Long orderId);
 }

--- a/src/main/java/com/farmer/backend/domain/orders/OrderQueryRepositoryImpl.java
+++ b/src/main/java/com/farmer/backend/domain/orders/OrderQueryRepositoryImpl.java
@@ -1,11 +1,14 @@
 package com.farmer.backend.domain.orders;
 
+import com.farmer.backend.api.controller.admin.order.response.ResponseOrderDetailDto;
 import com.farmer.backend.api.controller.admin.order.response.ResponseOrderListDto;
 import com.farmer.backend.api.controller.admin.orderproduct.response.ResponseOrderProductDto;
 import com.farmer.backend.api.controller.user.options.response.ResponseOptionDto;
 import com.farmer.backend.api.controller.user.order.request.SearchOrdersCondition;
 import com.farmer.backend.api.controller.user.order.response.ResponseOrdersAndPaymentDto;
 import com.farmer.backend.api.controller.user.order.response.ResponseOrdersDto;
+import com.farmer.backend.domain.delivery.QDelivery;
+import com.farmer.backend.domain.deliveryaddress.QDeliveryAddress;
 import com.farmer.backend.domain.orderproduct.QOrderProduct;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -19,6 +22,8 @@ import javax.persistence.EntityManager;
 
 import java.util.List;
 
+import static com.farmer.backend.domain.delivery.QDelivery.delivery;
+import static com.farmer.backend.domain.deliveryaddress.QDeliveryAddress.deliveryAddress;
 import static com.farmer.backend.domain.member.QMember.member;
 import static com.farmer.backend.domain.orderproduct.QOrderProduct.orderProduct;
 import static com.farmer.backend.domain.orders.QOrders.orders;
@@ -97,6 +102,24 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
                 .where(orders.id.eq(orderId))
                 .fetch();
         return fetch;
+    }
+
+    @Override
+    public ResponseOrderDetailDto findByOrderDetail(Long orderId) {
+        return query
+                .select(Projections.constructor(
+                        ResponseOrderDetailDto.class,
+                        orders.orderNumber,
+                        orders.createdDate,
+                        orders.member.nickname,
+                        deliveryAddress.hp,
+                        orders.delivery.address,
+                        orders.member.email
+                ))
+                .from(orders)
+                .leftJoin(deliveryAddress).on(deliveryAddress.member.eq(orders.member))
+                .where(orders.id.eq(orderId))
+                .fetchOne();
     }
 
     private BooleanExpression likeOrderNumber(String orderNumber) {

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -6,7 +6,7 @@ spring:
           kakao:
             client-id: a75882f783c2d87ec3f798d330ffb7f2
             client-secret: 0EAIYvVjbeqd7Zy70TWJNf5z3b9hmsNV
-            redirect-uri: https://farmer-clone.vercel.app/login/kakao
+            redirect-uri: https://front-end-farmer-shop.vercel.app/login/kakao
             client-authentication-method: POST
             authorization-grant-type: authorization_code
             scope: account_email, profile_nickname
@@ -15,7 +15,7 @@ spring:
           naver:
             client-id: HWQ9BzAAb1xWKWm0U6aV
             client-secret: CDhbwZpz57
-            redirect-uri: https://farmer-clone.vercel.app/login/naver
+            redirect-uri: https://front-end-farmer-shop.vercel.app/login/naver
             authorization-grant-type: authorization_code
             scope: email, name
             client-name: Naver
@@ -23,7 +23,7 @@ spring:
           google:
             client-id: 555482867273-rf3vnh1tqf9omcab07dfamq48elo5qho.apps.googleusercontent.com
             client-secret: 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
-            redirect-uri: https://farmer-clone.vercel.app/login/google
+            redirect-uri: https://front-end-farmer-shop.vercel.app/login/google
             scope: profile,email
 
         provider:


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #322 


### ✅ 작업한 내용
- [x] 기존 어드민 컨트롤러의 주문관리 로직을 삭제하고, 도메인 별로 나누어 어드민 로직 개발
- [x] 주문관리 페이지의 주문 상세정보 API 개발 

- Resolved: #322 
